### PR TITLE
Knob extensions

### DIFF
--- a/lib/capistrano/tasks/torquebox/deploy.rake
+++ b/lib/capistrano/tasks/torquebox/deploy.rake
@@ -34,6 +34,13 @@ def create_deployment_descriptor(root_path)
     dd['stomp']['host'] = fetch(:stomp_host)
   end
 
+
+  filename = fetch(:knob_yml_extensions)
+  if filename
+    dd_ext = YAML.load_file(filename)
+    dd.merge! dd_ext
+  end
+
   dd
 end
 


### PR DESCRIPTION
I have to add more deployment information on my knob.yml. In my case, I have to add jobs.
This change allows to create a extension yml that will be merged on generated deployment descriptor.

Can you add this on a new version? and deploy on rubygems.org ?

Thanks
