### PR TITLE
upstart scripts are not executable

### DIFF
--- a/lib/capistrano/tasks/torquebox/deploy.rake
+++ b/lib/capistrano/tasks/torquebox/deploy.rake
@@ -131,7 +131,7 @@ namespace :deploy do
         when 'runit'
           execute "test -x #{fetch(:jboss_runit_script)}"
         when 'upstart'
-          execute "test -x #{fetch(:jboss_upstart_script)}"
+          execute "test -f #{fetch(:jboss_upstart_script)}"
         end
 
         execute "test -d #{fetch(:jboss_home)}"


### PR DESCRIPTION
upstart scripts are regular files and fail the `test -x` check.
