### PR TITLE
Convert the rails_env variable to string

### DIFF
--- a/lib/capistrano/tasks/torquebox/deploy.rake
+++ b/lib/capistrano/tasks/torquebox/deploy.rake
@@ -26,7 +26,7 @@ def create_deployment_descriptor(root_path)
 
   if  fetch(:rails_env)
     dd['environment'] ||= {}
-    dd['environment']['RACK_ENV'] = fetch(:rails_env)
+    dd['environment']['RACK_ENV'] = fetch(:rails_env).to_s
   end
 
   if fetch(:stomp_host)


### PR DESCRIPTION
When using capistrano-torquebox in conjunction with capistrano-rails the
variable `rails_env` may be set to a symbol instead of a string.

If the user does not explicitly set `rails_env` it will be inferred from
the current Capistrano stage and in this case stages are represented by
symbols.

When we convert the deployment descriptor hash to yaml, YAML.dump turns
symbols like `:production` into the string `":production"` instead of
`"production"`

As a consequence, the -knob.yml deployment descriptor ends up with:

```
environment:
  RACK_ENV: :production
```

Which brakes the deploy because `":production"` is not the desired
environment, it's not even valid in most/all rails setups.