### PR TITLE
Add sudo when dealing with upstart services

### DIFF
--- a/lib/capistrano/tasks/torquebox/deploy.rake
+++ b/lib/capistrano/tasks/torquebox/deploy.rake
@@ -66,7 +66,7 @@ namespace :deploy do
         when 'runit'
           execute "sv start torquebox"
         when 'upstart'
-          execute "service torquebox start"
+          sudo "service torquebox start"
         end
       end
     end
@@ -84,7 +84,7 @@ namespace :deploy do
           when 'runit'
             execute "sv stop torquebox"
           when 'upstart'
-            execute "service torquebox stop"
+            sudo "service torquebox stop"
         end
       end
     end
@@ -104,7 +104,7 @@ namespace :deploy do
             execute "sv restart torquebox"
           when 'upstart'
             info    "Restarting TorqueBox AS"
-            execute "service torquebox restart"
+            sudo "service torquebox restart"
         end
       end
     end


### PR DESCRIPTION
When a user tries to stop, start or restart an Upstart job, it needs to
be a privileged user.

The user could run the TorqueBox service under a Upstart Session Init
and as such it could manage the service as an unprivileged user, but
according to the [Upstart documentation](http://upstart.ubuntu.com/cookbook/#session-init)
it is "not fully supported [on servers] right now."